### PR TITLE
fix: use zlib fossils URL to support any version

### DIFF
--- a/pipeline/build-wasi-libs.sh
+++ b/pipeline/build-wasi-libs.sh
@@ -20,7 +20,7 @@ mkdir -p "$WORK"
 # --- zlib ---
 echo "Building zlib $ZLIB_VERSION for WASI..."
 cd "$WORK"
-curl -fsSL "https://zlib.net/zlib-${ZLIB_VERSION}.tar.gz" | tar -xzf -
+curl -fsSL "https://zlib.net/fossils/zlib-${ZLIB_VERSION}.tar.gz" | tar -xzf -
 cd "zlib-${ZLIB_VERSION}"
 
 CC="$CC" CFLAGS="$CFLAGS" AR="$AR" RANLIB="$RANLIB" \


### PR DESCRIPTION
The zlib.net root URL only serves the current/latest release. Using the /fossils/ path ensures the specified version can always be fetched, regardless of whether it is the current release.

Closes [Issue 19](https://github.com/6over3/zeroperl/issues/19)