### PR TITLE
fix(wasm): expand ZEROPERL_IMPORT compilation guard for WebAssembly c…

### DIFF
--- a/stubs/zeroperl.c
+++ b/stubs/zeroperl.c
@@ -24,7 +24,7 @@
 
 //! Export macro for public API functions - combines export_name for WASI with
 //! visibility attribute
-#if defined(__WASI__) || defined(__wasi__)
+#if defined(__WASI__) || defined(__wasi__) || defined(__wasm__) || defined(__EMSCRIPTEN__)
 #define ZEROPERL_API(name)                                                     \
   __attribute__((export_name(name))) __attribute__((visibility("default")))
 #define ZEROPERL_IMPORT(name)                                                  \


### PR DESCRIPTION
Title: fix: expand ZEROPERL_IMPORT compilation guard for WebAssembly compatibility #23
Description:
This PR resolves issue #23 where self-built WebAssembly modules failed to load in the host environment with the error: import object field 'call_host_function' is not a Function.
The Problem
The ZEROPERL_IMPORT macro was conditionally compiled only when __WASI__ or __wasi__ was defined. In certain local build environments or alternative WASM/Emscripten targets, the compiler may define __wasm__ or __EMSCRIPTEN__ instead, causing the macro to fall back to an empty definition. This meant the host_call_function was compiled as a normal C function, omitting the necessary WebAssembly import module and name metadata from the generated .wasm binary.
The Fix
Expanded the conditional compilation guard in stubs/zeroperl.c to explicitly support __wasm__ and __EMSCRIPTEN__. This ensures that any WebAssembly compiler correctly outputs the import_module("env") and import_name("call_host_function") attributes, guaranteeing runtime compatibility in all host environments.
Closes #23
@opire solve